### PR TITLE
FFS-2168: Header-basert ingress-routing for Bearer ved siden av SSO-cookie

### DIFF
--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -27,10 +27,15 @@ spec:
     hostname: flyt.vigoiks.no
     basePath: ""
   ingress:
-    enabled: true
-    basePath: path
-    middlewares:
-      - fint-flyt-auth-forward-sso
+    routes:
+      - host: flyt.vigoiks.no
+        path: path
+        headers:
+          Authorization: "re:.+"
+      - host: flyt.vigoiks.no
+        path: path
+        middlewares:
+          - fint-flyt-auth-forward-sso
   env:
     - name: JAVA_TOOL_OPTIONS
       value: '-XX:+ExitOnOutOfMemoryError -Xmx1840M'

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/afk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/afk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/afk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/afk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/agderfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/agderfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/agderfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/agderfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/bfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/bfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-discovery-service_bym_oslo_kommune_no
+      app.kubernetes.io/instance: fint-flyt-discovery-service_bym-oslo-kommune-no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-discovery-service_bym-oslo-kommune-no
+      app.kubernetes.io/instance: fint-flyt-discovery-service_bym_oslo_kommune_no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bym-oslo-kommune-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bym-oslo-kommune-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ffk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ffk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ffk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ffk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "fintlabs.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/fintlabs-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/fintlabs-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/innlandetfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/innlandetfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/innlandetfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/innlandetfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "mrfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/mrfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/mrfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "nfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/nfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/nfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ofk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ofk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ofk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ofk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/rogfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/rogfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/rogfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/rogfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/telemarkfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/telemarkfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/telemarkfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/telemarkfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/tromsfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/tromsfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/tromsfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/tromsfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/trondelagfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/trondelagfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/trondelagfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/trondelagfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vestfoldfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vestfoldfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vestfoldfylke-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vestfoldfylke-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vlfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vlfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vlfk-no/api/intern/metadata"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vlfk-no/api/intern/metadata"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "$ORG_ID"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "$INGRESS_BASE_PATH"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "$INGRESS_BASE_PATH"
       - op: add
         path: "/spec/env/-"


### PR DESCRIPTION
## Summary

Legger til header-basert ingress-routing i fint-flyt-discovery-service slik at API-et kan tas med `Authorization: Bearer` direkte (M2M / omskrevet frontend) ved siden av dagens SSO-cookie-flyt.

SSO-middlewaren `fint-flyt-auth-forward-sso` er en Traefik `forwardAuth` som veksler `user_session`-cookie til `Authorization: Bearer`. Med den aktiv får en request uten cookie `307` mot IDP (når aldri backend), og en klient-satt `Authorization` overskrives. Tjenesten er allerede OAuth2 resource server (`no.novari:flyt-web-resource-server`) som validerer JWT direkte, så dette er ren ingress-konfig — ingen backend-kode.

## Endringer

- `kustomize/base/flais.yaml`: bytter legacy `ingress` (`enabled`/`basePath`/`middlewares`) til flaiserator `routes`-form med to ruter på samme host (`flyt.vigoiks.no`):
  - Rute uten middleware som matcher `HeadersRegexp(Authorization, .+)` → Bearer forbikjører SSO.
  - Rute med `fint-flyt-auth-forward-sso` → dagens cookie/SSO-flyt.
- `kustomize/templates/overlay.yaml.tpl`: patcher nå `routes[0].path` og `routes[1].path` (samme per-tenant path) i stedet for `ingress.basePath`.
- Regenererte alle 28 overlays via `script/render-overlay.sh`.

## Verifisering

`kubectl kustomize` av alle 28 overlays bygger feilfritt og rendrer begge rutene med riktig per-tenant path (`/<tenant>/api/intern/metadata`, beta prefikset `/beta`), med korrekt host, headers og middleware. Selve `IngressRoute` genereres av flaiserator i runtime, ikke av kustomize.

## Åpne punkter

- Traefik-prioritet: flaiserator eksponerer ikke eksplisitt `priority`; vi lener oss på at lengste regel (header-ruten) vinner. Bekreftes i runtime.
- `/api/intern-klient` (client-credentials): tjenesten eksponerer kun `/api/intern/metadata` (USER), så ren client-credentials-M2M treffer ikke denne pathen. Utenfor scope for denne tasken.

Del av epic FFS-2164. https://novari-iks.atlassian.net/browse/FFS-2168