### PR TITLE
FFS-2174 Bruk felles GitHub workflows

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -7,91 +7,39 @@ on:
     types:
       - completed
 
-env:
-  REGISTRY: ghcr.io
-
-permissions:
-  contents: read
-  packages: read
-
 jobs:
-  deploy-to-aks:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        org:
-          - afk-no
-          - agderfk-no
-          - bfk-no
-          - bym-oslo-kommune-no
-          - ffk-no
-          - fintlabs-no
-          - innlandetfylke-no
-          - mrfylke-no
-          - nfk-no
-          - ofk-no
-          - rogfk-no
-          - telemarkfylke-no
-          - tromsfylke-no
-          - trondelagfylke-no
-          - vestfoldfylke-no
-          - vlfk-no
-        cluster:
-          - aks-beta-fint-2021-11-23
-          - aks-api-fint-2022-02-08
-        exclude:
-          - org: bym-oslo-kommune-no
-            cluster: aks-beta-fint-2021-11-23
-          - org: fintlabs-no
-            cluster: aks-api-fint-2022-02-08
-          - org: mrfylke-no
-            cluster: aks-beta-fint-2021-11-23
-          - org: nfk-no
-            cluster: aks-beta-fint-2021-11-23
-
-    steps:
-      - uses: actions/checkout@v5
-      - run: echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
-      - uses: actions/github-script@v8
-        id: environment
-        with:
-          script: return '${{ matrix.cluster }}'.split('-')[1]
-          result-encoding: string
-      - uses: actions/github-script@v8
-        id: resource-group
-        with:
-          script: return 'rg-aks-${{ steps.environment.outputs.result }}'
-          result-encoding: string
-      - uses: azure/k8s-bake@v3
-        id: bake
-        with:
-          renderEngine: kustomize
-          kustomizationPath: kustomize/overlays/${{ matrix.org }}/${{ steps.environment.outputs.result }}
-      - uses: azure/login@v2
-        with:
-          creds: ${{ secrets[ format('AKS_{0}_FINT_GITHUB', steps.environment.outputs.result) ] }}
-      - uses: azure/use-kubelogin@v1
-        with:
-          kubelogin-version: 'v0.0.32'
-      - uses: azure/aks-set-context@v4
-        with:
-          cluster-name: ${{ matrix.cluster }}
-          resource-group: ${{ steps.resource-group.outputs.result }}
-          admin: true
-          use-kubelogin: true
-      - uses: azure/k8s-deploy@v5.0.3
-        with:
-          action: deploy
-          manifests: ${{ steps.bake.outputs.manifestsBundle }}
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
-          namespace: ${{ matrix.org }}
+  deploy:
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-cd-deploy.yaml@main
+    with:
+      deploy-targets: |
+        [
+          {"org":"afk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"afk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"agderfk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"agderfk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"bfk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"bfk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"bym-oslo-kommune-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"ffk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"ffk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"fintlabs-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"innlandetfylke-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"innlandetfylke-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"mrfylke-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"nfk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"ofk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"ofk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"rogfk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"rogfk-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"telemarkfylke-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"telemarkfylke-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"tromsfylke-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"tromsfylke-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"trondelagfylke-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"trondelagfylke-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"vestfoldfylke-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"vestfoldfylke-no","cluster":"aks-api-fint-2022-02-08"},
+          {"org":"vlfk-no","cluster":"aks-beta-fint-2021-11-23"},
+          {"org":"vlfk-no","cluster":"aks-api-fint-2022-02-08"}
+        ]
+    secrets: inherit

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
     with:
       push-image: ${{ github.event_name == 'push' }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,46 +1,14 @@
 name: CI Build
+
 on:
   pull_request:
   push:
     branches:
       - main
-env:
-  REGISTRY: ghcr.io
-permissions:
-  contents: read
-  packages: write
+
 jobs:
   build:
-    name: Build & Publish Image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-      - name: Set up Java 25
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '25'
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
-        with:
-          gradle-version: wrapper
-      - name: Build with Gradle
-        run: ./gradlew build
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Derive lowercase image name
-        run: echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-      - id: build-image
-        name: Build & Push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
+    with:
+      push-image: ${{ github.event_name == 'push' }}
+    secrets: inherit

--- a/.github/workflows/MD.yaml
+++ b/.github/workflows/MD.yaml
@@ -33,6 +33,9 @@ on:
           - vlfk-no
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
     with:
       push-image: true

--- a/.github/workflows/MD.yaml
+++ b/.github/workflows/MD.yaml
@@ -4,15 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       cluster:
-        description: 'Select an environment'
+        description: Select environment
         required: true
         type: choice
         options:
-          - aks-alpha-fint-2021-11-18
           - aks-beta-fint-2021-11-23
           - aks-api-fint-2022-02-08
       org:
-        description: 'Select organisation'
+        description: Select organisation
         required: true
         type: choice
         options:
@@ -25,90 +24,25 @@ on:
           - innlandetfylke-no
           - mrfylke-no
           - nfk-no
-          - bym-oslo-kommune-no
+          - ofk-no
           - rogfk-no
           - telemarkfylke-no
           - tromsfylke-no
           - trondelagfylke-no
           - vestfoldfylke-no
           - vlfk-no
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  CLUSTER_NAME: ${{ inputs.cluster }}
-  ORG: ${{ inputs.org }}
-
 jobs:
+  build:
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
+    with:
+      push-image: true
+    secrets: inherit
+
   deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    concurrency:
-      group: manual-deploy-${{ inputs.cluster }}-${{ inputs.org }}
-      cancel-in-progress: false
-    steps:
-      - name: Determine resource group
-        id: rg
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const p='${{ inputs.cluster }}'.split('-'); return `rg-${p[0]}-${p[1]}`;
-          result-encoding: string
-      - name: Determine env key
-        id: environment
-        uses: actions/github-script@v8
-        with:
-          script: return '${{ inputs.cluster }}'.split('-')[1];
-          result-encoding: string
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '25'
-      - uses: gradle/actions/wrapper-validation@v5
-      - uses: gradle/actions/setup-gradle@v5
-        with:
-          gradle-version: wrapper
-      - run: ./gradlew build
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - id: bake
-        uses: azure/k8s-bake@v3
-        with:
-          renderEngine: 'kustomize'
-          kustomizationPath: kustomize/overlays/${{ env.ORG }}/${{ steps.environment.outputs.result }}
-      - name: Determine secret name
-        id: secretname
-        run: |
-          echo "SECRET_NAME=$(echo AKS_${{ steps.environment.outputs.result }}_FINT_GITHUB | tr '[:lower:]' '[:upper:]')" >> $GITHUB_OUTPUT
-      - uses: azure/login@v2
-        with:
-          creds: ${{ secrets[ steps.secretname.outputs.SECRET_NAME ] }}
-      - uses: azure/aks-set-context@v4
-        with:
-          cluster-name: ${{ env.CLUSTER_NAME }}
-          resource-group: ${{ steps.rg.outputs.result }}
-          admin: true
-          use-kubelogin: true
-      - uses: azure/k8s-deploy@v5.0.3
-        with:
-          action: deploy
-          manifests: ${{ steps.bake.outputs.manifestsBundle }}
-          images: ${{ steps.meta.outputs.tags }}
-          namespace: ${{ env.ORG }}
+    needs: build
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-deploy-aks.yaml@main
+    with:
+      org: ${{ inputs.org }}
+      cluster: ${{ inputs.cluster }}
+      image-ref: ${{ needs.build.outputs.image-ref }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace repository-local CI/CD/MD implementation with reusable workflows from `FINTLabs/fint-flyt-github-workflows`.
- Keep repository-specific deploy targets based on existing `kustomize/overlays`.

## Validation
- YAML parse completed for changed workflow files.
- `git diff --check` completed.
- Deploy targets were verified against existing overlays.