### PR TITLE
FFS-2184 Migrer discovery-service til HTTP-basert autorisering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Base path: `/api/intern/metadata`
 | `GET` | `/{metadataId}/instans-metadata` | Fetch the instance metadata content for a given integration metadata ID. | – | `200 OK` with `InstanceMetadataContentDto`; `404` when missing; `403` if unauthorized. |
 | `POST` | `/` | Publish a new integration metadata version. | `IntegrationMetadataDto` (validated; must be a unique version per source application/integration). | `200 OK` on success; `409` if version exists; `422` on validation errors. |
 
-All endpoints are secured; `UserAuthorizationService` checks the caller’s access to the referenced `sourceApplicationId` and returns `403 Forbidden` when claims do not permit access.
+All endpoints are secured. `UserAuthorizationService` checks the caller’s access to the referenced
+`sourceApplicationId` through authorization-service and returns `403 Forbidden` when access is denied.
 
 ## Kafka Integration
 
@@ -51,7 +52,8 @@ No scheduled jobs run in this service; it reacts to Kafka events and HTTP reques
 
 ## Configuration
 
-The application layers on the shared Spring profiles `flyt-kafka`, `flyt-logging`, `flyt-resource-server`, and `flyt-postgres`.
+The application layers on the shared Spring profiles `flyt-kafka`, `flyt-logging`, `flyt-web-resource-server`,
+`flyt-authorization-client`, and `flyt-postgres`.
 
 Key properties:
 
@@ -63,6 +65,7 @@ Key properties:
 | `spring.kafka.bootstrap-servers` | Kafka bootstrap URL (see `application-local-staging.yaml` for localhost defaults). |
 | `spring.datasource.*` | JDBC connection details for Postgres plus Hikari schema selection; secrets provided per environment. |
 | `spring.security.oauth2.resourceserver.jwt.issuer-uri` | OAuth issuer for validating internal API calls. |
+| `fint.flyt.authorization.sso.client-id` / `fint.flyt.authorization.sso.client-secret` | OAuth2 client credentials for calls to authorization-service. |
 | `novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json` | Org/role map for internal client authorization (rendered into overlays). |
 | `spring.jpa.hibernate.ddl-auto` / `spring.flyway.*` | Schema management; Flyway migrations are applied on startup. |
 
@@ -106,7 +109,7 @@ The script rewrites each `kustomization.yaml` with namespace-specific paths, Kaf
 ## Security
 
 - Runs as an OAuth2 resource server validating JWTs from `spring.security.oauth2.resourceserver.jwt.issuer-uri`.
-- Internal APIs are enabled via the shared `flyt-resource-server` profile and gated by `UserAuthorizationService`, which checks caller access to the requested `sourceApplicationId`.
+- Internal APIs are enabled via the shared `flyt-web-resource-server` profile and gated by `UserAuthorizationService`, which checks caller access to the requested `sourceApplicationId` over OAuth2-protected HTTP.
 
 ## Observability & Operations
 
@@ -129,4 +132,3 @@ The script rewrites each `kustomization.yaml` with namespace-specific paths, Kaf
 4. Add or update tests to cover new behaviour and edge cases.
 
 FINT Flyt Discovery Service is maintained by the FINT Flyt team. Contact the team via the internal Slack channel or open an issue in this repository for questions or enhancements.
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-resource-server:3.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 
     implementation("org.flywaydb:flyway-core")

--- a/src/main/kotlin/no/novari/flyt/discovery/service/IntegrationMetadataController.kt
+++ b/src/main/kotlin/no/novari/flyt/discovery/service/IntegrationMetadataController.kt
@@ -58,8 +58,14 @@ class IntegrationMetadataController(
         @RequestParam(name = "kildeapplikasjonIds") sourceApplicationIds: Collection<Long>,
         @RequestParam(name = "bareSisteVersjoner", required = false) onlyLatestVersions: Boolean?,
     ): ResponseEntity<Map<Long, Collection<IntegrationMetadataDto>>> {
-        sourceApplicationIds.forEach { sourceApplicationId ->
-            userAuthorizationService.checkIfUserHasAccessToSourceApplication(authentication, sourceApplicationId)
+        val requestedSourceApplicationIds = sourceApplicationIds.toSet()
+        val authorizedSourceApplicationIds =
+            userAuthorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                requestedSourceApplicationIds,
+            )
+        if (!authorizedSourceApplicationIds.containsAll(requestedSourceApplicationIds)) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN)
         }
 
         val integrationMetadata =

--- a/src/main/resources/application-flyt-authorization-client.yaml
+++ b/src/main/resources/application-flyt-authorization-client.yaml
@@ -3,6 +3,10 @@ novari:
     audit:
       authorization:
         base-url: 'http://fint-flyt-authorization-service:8080${server.servlet.context-path:}'
+    web-resource-server:
+      security:
+        authorization:
+          base-url: 'http://fint-flyt-authorization-service:8080${server.servlet.context-path:}'
 
 spring:
   security:

--- a/src/test/kotlin/no/novari/flyt/discovery/service/IntegrationMetadataControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/discovery/service/IntegrationMetadataControllerTest.kt
@@ -17,7 +17,6 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
@@ -80,6 +79,13 @@ class IntegrationMetadataControllerTest {
     fun `returns 200 when integration metadata is found for multiple source applications`() {
         val dto = validIntegrationMetadataDto()
         val sourceApplicationIds = listOf(1L, 2L)
+        val requestedSourceApplicationIds = setOf(1L, 2L)
+        whenever(
+            userAuthorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                requestedSourceApplicationIds,
+            ),
+        ).thenReturn(requestedSourceApplicationIds)
         whenever(integrationMetadataService.getIntegrationMetadataForSourceApplications(sourceApplicationIds, false))
             .thenReturn(
                 mapOf(
@@ -95,8 +101,10 @@ class IntegrationMetadataControllerTest {
                 null,
             )
 
-        verify(userAuthorizationService, times(1)).checkIfUserHasAccessToSourceApplication(authentication, 1L)
-        verify(userAuthorizationService, times(1)).checkIfUserHasAccessToSourceApplication(authentication, 2L)
+        verify(userAuthorizationService).getUserAuthorizedSourceApplicationIds(
+            authentication,
+            requestedSourceApplicationIds,
+        )
         assertEquals(HttpStatus.OK, response.statusCode)
         assertNotNull(response.body)
         assertEquals(2, response.body?.size)
@@ -127,12 +135,13 @@ class IntegrationMetadataControllerTest {
 
     @Test
     fun `throws forbidden when user lacks access to one of several source applications`() {
-        doThrow(
-            ResponseStatusException(
-                HttpStatus.FORBIDDEN,
-                "You do not have permission to access or modify data that is related to source application with id=2",
+        val requestedSourceApplicationIds = setOf(1L, 2L)
+        whenever(
+            userAuthorizationService.getUserAuthorizedSourceApplicationIds(
+                authentication,
+                requestedSourceApplicationIds,
             ),
-        ).whenever(userAuthorizationService).checkIfUserHasAccessToSourceApplication(authentication, 2L)
+        ).thenReturn(setOf(1L))
 
         val exception =
             assertThrows(ResponseStatusException::class.java) {
@@ -140,9 +149,9 @@ class IntegrationMetadataControllerTest {
             }
 
         assertEquals(HttpStatus.FORBIDDEN, exception.statusCode)
-        assertEquals(
-            "You do not have permission to access or modify data that is related to source application with id=2",
-            exception.reason,
+        verify(userAuthorizationService).getUserAuthorizedSourceApplicationIds(
+            authentication,
+            requestedSourceApplicationIds,
         )
     }
 


### PR DESCRIPTION
## Summary

Migrerer discovery-service til `fint-flyt-web-resource-server:4.0.0-rc-1` og HTTP-basert brukerautorisering.

- Beholder eksisterende OAuth2-CRD og secret-injeksjon.
- Oppdaterer enkeltsjekker slik at source application-tilgang verifiseres via authorization-service.
- Fjerner avhengigheten av at Kafka-cache er varmet opp før første request.

## Bakgrunn

Kafka-cache kan forsinke tilgjengelige rettigheter etter pod-oppstart. HTTP-autorisering gir korrekt tilgangsvurdering på første request.

## Verifisering

`./gradlew --no-daemon check`

Kustomize-basen renderer OAuth2 `client_credentials`-ressursen og secret-referansene.